### PR TITLE
Ancient sword bugfix (Thaumcraft aspects lookup)

### DIFF
--- a/147/mod/fossil/common/items/ItemAncientsword.java
+++ b/147/mod/fossil/common/items/ItemAncientsword.java
@@ -48,9 +48,8 @@ public class ItemAncientsword extends ItemSword
                 var1.worldObj.spawnEntityInWorld(var3);
                 var3.Mouth.SendSpeech(EnumPigmenSpeaks.LifeFor, var3.LeaderName);
             }
+            var1.worldObj.addWeatherEffect(new EntityMLighting(var1.worldObj, var1.posX, var1.posY, var1.posZ));
         }
-
-        var1.worldObj.addWeatherEffect(new EntityMLighting(var1.worldObj, var1.posX, var1.posY, var1.posZ));
         return 4 + EnumToolMaterial.IRON.getDamageVsEntity() * 2;
     }
 


### PR DESCRIPTION
Fixes null pointer exception if getDamageVsEntity(null) is called.
